### PR TITLE
Hide symbols names when building for mac/arm64

### DIFF
--- a/src/arm/asm.S
+++ b/src/arm/asm.S
@@ -94,6 +94,8 @@
 #ifdef __ELF__
         .type   EXTERN\name, %function
         .hidden EXTERN\name
+#elif defined(__MACH__)
+        .private_extern EXTERN\name
 #endif
 #if HAVE_AS_FUNC
         .func   EXTERN\name


### PR DESCRIPTION
This matches the `.hidden` already used for ELF outputs.

This is needed for Chromium's mac/arm64 build. Chromium has a build step
that verifies that Chromium Framework only exports a small, fixed set of symbols.
The dav1d symbols showed up unexpectedly. This fixes that.